### PR TITLE
Perform configuration watching via libcosmic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
+      - name: Disable mandb triggers
+        run: |
+          echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
+          sudo dpkg-reconfigure man-db
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -319,6 +319,7 @@ version = "0.0.0"
 dependencies = [
  "atomic_refcell",
  "cbindgen",
+ "cosmic-settings-daemon",
  "libcosmic",
 ]
 
@@ -757,7 +758,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -777,7 +778,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -813,7 +814,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#37cbe4e8c165428178be23a14bd37f19a19d3757"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#b2337437d70b3db7a56211a43aa1632306711b2d"
 dependencies = [
  "zbus",
 ]
@@ -821,7 +822,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#6514323fbe764998415068e3ae40cf476753d425"
+source = "git+https://github.com/pop-os/cosmic-text.git#cffdea2b334e7830a5fd6f95bf5e1784014442a8"
 dependencies = [
  "bitflags 2.9.4",
  "fontdb 0.23.0",
@@ -844,7 +845,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1872,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "dnd",
  "iced_core",
@@ -1888,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "bitflags 2.9.4",
  "bytes",
@@ -1911,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "futures",
  "iced_core",
@@ -1936,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "bitflags 2.9.4",
  "bytemuck",
@@ -1958,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1970,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "bytes",
  "dnd",
@@ -1984,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2000,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.9.4",
@@ -2031,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "dnd",
  "iced_renderer",
@@ -2366,7 +2367,7 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#4c4eddb50c79ace202c76b0f6972596930537e1b"
+source = "git+https://github.com/pop-os/libcosmic#76c1897d4d9a637c8aa4016483bf05fec5f10ebd"
 dependencies = [
  "apply",
  "auto_enums",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 libcosmic = { git = "https://github.com/pop-os/libcosmic", default-features = false }
+cosmic-settings-daemon = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 atomic_refcell = "0.1.13"
 
 [build-dependencies]

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -15,3 +15,4 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 mod theme;
+mod watcher;

--- a/bindings/src/watcher.rs
+++ b/bindings/src/watcher.rs
@@ -1,0 +1,188 @@
+/*
+ * This file is part of CuteCosmic.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+use std::{any::TypeId, cell::RefCell, ffi::c_void, rc::Rc, task::Poll};
+
+use atomic_refcell::AtomicRefCell;
+use cosmic::{
+    config::CosmicTk,
+    cosmic_config::{self, CosmicConfigEntry},
+    cosmic_theme::{Theme, ThemeMode},
+    iced::{
+        Executor, Subscription,
+        futures::{
+            Sink,
+            channel::{mpsc::SendError, oneshot},
+            executor::block_on,
+            task::SpawnExt,
+        },
+    },
+    iced_futures::subscription::into_recipes,
+};
+use cosmic_settings_daemon::CosmicSettingsDaemonProxy;
+
+static EXECUTOR_STOP: AtomicRefCell<Option<oneshot::Sender<()>>> = AtomicRefCell::new(None);
+
+/// Very simple iced executor that does everything on the thread it is run on,
+/// blocking it until notified to stop
+#[derive(Clone)]
+struct LocalExecutor {
+    pool: Rc<RefCell<cosmic::iced::futures::executor::LocalPool>>,
+}
+
+impl LocalExecutor {
+    fn run(&mut self) {
+        let rx = {
+            let mut stop = EXECUTOR_STOP.borrow_mut();
+            if stop.is_some() {
+                panic!("Executor already running!");
+            }
+
+            let (tx, rx) = oneshot::channel::<()>();
+            *stop = Some(tx);
+            rx
+        };
+        let _ = self.pool.borrow_mut().run_until(rx);
+    }
+}
+
+impl Executor for LocalExecutor {
+    fn new() -> Result<Self, cosmic::iced::futures::io::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            pool: Rc::new(RefCell::new(
+                cosmic::iced::futures::executor::LocalPool::new(),
+            )),
+        })
+    }
+
+    fn spawn(&self, future: impl Future<Output = ()> + cosmic::iced_futures::MaybeSend + 'static) {
+        self.pool.borrow().spawner().spawn(future).unwrap();
+    }
+}
+
+/// Implementation of `Sink` that just invokes a FFI function pointer each time
+/// a new item arrives
+#[derive(Clone)]
+struct CallbackSink {
+    callback: extern "C" fn(*mut c_void) -> c_void,
+    data: *mut c_void,
+}
+
+unsafe impl Send for CallbackSink {}
+
+impl Sink<()> for CallbackSink {
+    type Error = SendError;
+
+    fn poll_ready(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: std::pin::Pin<&mut Self>, _item: ()) -> Result<(), Self::Error> {
+        (self.callback)(self.data);
+        Ok(())
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn watch_config<I, T>(
+    proxy: Option<&CosmicSettingsDaemonProxy<'static>>,
+    config_id: &'static str,
+) -> Subscription<()>
+where
+    I: 'static,
+    T: 'static + Send + Sync + PartialEq + Clone + Default + CosmicConfigEntry,
+{
+    let sub = if let Some(daemon) = proxy {
+        cosmic_config::dbus::watcher_subscription::<T>(daemon.clone(), config_id, false)
+    } else {
+        cosmic_config::config_subscription::<_, T>(TypeId::of::<I>(), config_id.into(), T::VERSION)
+    };
+
+    // Since we don't care what exactly changed, just that something relevant
+    // did - this erases the update type so we can watch all the configuration
+    // entries we care about in one subscription
+    sub.map(|_update| ())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn libcosmic_watcher_start(
+    callback: extern "C" fn(*mut c_void) -> c_void,
+    data: *mut c_void,
+) {
+    struct ThemeModeSubscription;
+    struct DarkThemeSubscription;
+    struct LightThemeSubscription;
+    struct CosmicTkSubscription;
+
+    let sender = CallbackSink { callback, data };
+
+    std::thread::Builder::new()
+        .name("CuteCosmicWatcher".into())
+        .spawn(move || {
+            let proxy = block_on(cosmic_config::dbus::settings_daemon_proxy()).ok();
+
+            let sub = Subscription::batch([
+                watch_config::<ThemeModeSubscription, ThemeMode>(
+                    proxy.as_ref(),
+                    cosmic::cosmic_theme::THEME_MODE_ID,
+                ),
+                watch_config::<DarkThemeSubscription, Theme>(
+                    proxy.as_ref(),
+                    cosmic::cosmic_theme::DARK_THEME_ID,
+                ),
+                watch_config::<LightThemeSubscription, Theme>(
+                    proxy.as_ref(),
+                    cosmic::cosmic_theme::LIGHT_THEME_ID,
+                ),
+                watch_config::<CosmicTkSubscription, CosmicTk>(proxy.as_ref(), cosmic::config::ID),
+            ]);
+
+            let mut executor = LocalExecutor::new().unwrap();
+            let mut rt: cosmic::iced_futures::Runtime<_, _, ()> =
+                cosmic::iced_futures::Runtime::new(executor.clone(), sender);
+
+            rt.track(into_recipes(sub));
+
+            executor.run();
+        })
+        .unwrap();
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn libcosmic_watcher_stop() {
+    if let Some(tx) = EXECUTOR_STOP.borrow_mut().take() {
+        let _ = tx.send(());
+    }
+}

--- a/platformtheme/cutecosmictheme.cpp
+++ b/platformtheme/cutecosmictheme.cpp
@@ -82,7 +82,8 @@ static std::unique_ptr<QFont> loadFont(CosmicFontKind kind)
 }
 
 CuteCosmicPlatformThemePrivate::CuteCosmicPlatformThemePrivate()
-    : d_requestedScheme(Qt::ColorScheme::Unknown)
+    : d_firstThemeChange(true)
+    , d_requestedScheme(Qt::ColorScheme::Unknown)
 {
     d_watcher = new CuteCosmicWatcher(this);
     connect(d_watcher, &CuteCosmicWatcher::themeChanged, this, &CuteCosmicPlatformThemePrivate::themeChanged);
@@ -121,6 +122,14 @@ void CuteCosmicPlatformThemePrivate::setColorScheme(Qt::ColorScheme scheme)
 
 void CuteCosmicPlatformThemePrivate::themeChanged()
 {
+    // A little bit of a hack - libcosmic configuration subscriptions emit the
+    // current value as soon as they are set up, and we don't need this. So
+    // ignore the first theme change notification.
+    if (d_firstThemeChange) {
+        d_firstThemeChange = false;
+        return;
+    }
+
     reloadTheme();
     QWindowSystemInterface::handleThemeChange();
 }

--- a/platformtheme/cutecosmictheme.h
+++ b/platformtheme/cutecosmictheme.h
@@ -47,6 +47,7 @@ private:
 
     CuteCosmicWatcher* d_watcher;
 
+    bool d_firstThemeChange;
     Qt::ColorScheme d_requestedScheme;
     std::unique_ptr<QPalette> d_systemPalette;
     std::unique_ptr<QFont> d_interfaceFont;

--- a/platformtheme/cutecosmicwatcher.h
+++ b/platformtheme/cutecosmicwatcher.h
@@ -26,14 +26,13 @@ class CuteCosmicWatcher : public QObject
 
 public:
     CuteCosmicWatcher(QObject* parent = nullptr);
-
-    void watchConfigurationChanges(const QString& id, qulonglong version);
+    ~CuteCosmicWatcher();
 
 Q_SIGNALS:
     void themeChanged();
 
 private Q_SLOTS:
-    void configurationChanged(QString id, QString key);
+    void configurationChanged();
 
 private:
     QTimer* d_themeChangedEmitTimer;


### PR DESCRIPTION
Implements #1.

Change from watching COSMIC configuration via D-Bus on the C++ side to doing so with the APIs provided by libcosmic on the Rust side. Use the D-Bus based API in first priority, falling back to the inotify based API if cosmic-settings-deamon is not available.

Watching is done on a dedicated background thread running a local async runtime.