### PR TITLE
Implement re-coloring icon engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following configuration is relayed from COSMIC settings to Qt applications:
 - [x] High contrast mode (Qt 6.10+)
 - [x] File dialogs
 - [x] Icon theme
+  - Including symbolic icon re-coloring to avoid dark-on-dark icons
 - [x] Fonts
 - [x] Color palette[^1]
 

--- a/platformtheme/CMakeLists.txt
+++ b/platformtheme/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 set(SOURCES
     cutecosmiccolormanager.cpp
     cutecosmicfiledialog.cpp
+    cutecosmiciconengine.cpp
     cutecosmictheme.cpp
     cutecosmicwatcher.cpp
     main.cpp

--- a/platformtheme/cutecosmiciconengine.cpp
+++ b/platformtheme/cutecosmiciconengine.cpp
@@ -1,0 +1,223 @@
+#include "cutecosmiciconengine.h"
+
+#include <QtGui/private/qguiapplication_p.h>
+
+#include <QBuffer>
+#include <QFile>
+#include <QGuiApplication>
+#include <QImageReader>
+#include <QPainter>
+#include <QPalette>
+#include <QPixmapCache>
+#include <QTextStream>
+#include <QXmlStreamReader>
+
+using namespace Qt::Literals;
+
+CuteCosmicIconEngine::CuteCosmicIconEngine(const QString& iconName)
+    : d_iconInfo(QIconLoader::instance()->loadIcon(iconName))
+{
+}
+
+QIconEngine* CuteCosmicIconEngine::clone() const
+{
+    return new CuteCosmicIconEngine(d_iconInfo.iconName);
+}
+
+QString CuteCosmicIconEngine::key() const
+{
+    return "CuteCosmicIconEngine"_L1;
+}
+
+QString CuteCosmicIconEngine::iconName()
+{
+    return d_iconInfo.iconName;
+}
+
+bool CuteCosmicIconEngine::isNull()
+{
+    return d_iconInfo.entries.empty();
+}
+
+void CuteCosmicIconEngine::paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state)
+{
+    qreal scale = (painter->device()) ? painter->device()->devicePixelRatio() : qGuiApp->devicePixelRatio();
+
+    QPixmap pixmap = scaledPixmap(rect.size(), mode, state, scale);
+    if (!pixmap.isNull()) {
+        painter->drawPixmap(rect, pixmap);
+    }
+}
+
+QPixmap CuteCosmicIconEngine::pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state)
+{
+    return scaledPixmap(size, mode, state, 1.0);
+}
+
+QPixmap CuteCosmicIconEngine::scaledPixmap(const QSize& size, QIcon::Mode mode, QIcon::State state, qreal scale)
+{
+    int iconSize = qMin(size.height(), size.width());
+
+    QString fileName = bestIconFileForSize(iconSize, scale);
+    if (fileName.isEmpty()) {
+        return QPixmap();
+    }
+
+    QSize targetSize { iconSize, iconSize };
+
+    if (!fileName.endsWith(".svg"_L1)) {
+        QIcon icon { fileName };
+        return icon.pixmap(targetSize, scale, mode, state);
+    }
+
+    QPixmap result = renderSvgIcon(fileName, targetSize * scale, mode, state);
+    result.setDevicePixelRatio(scale);
+    return result;
+}
+
+static bool isSymbolic(const QString& iconName)
+{
+    return iconName.endsWith("-symbolic"_L1)
+        || iconName.endsWith("-symbolic-rtl"_L1);
+}
+
+static bool isKdeSymbolicIcon(const QByteArray& svg)
+{
+    // Breeze icons are mostly symbolic, but not always found as such because
+    // of the internal symlinks in the theme. Furthermore, the way that KDE
+    // symbolic icons are re-colored is by a stylesheet embedded into the icon
+    // itself, which is replaced by KIconLoader prior to rendering. Try to
+    // identify this stylesheet.
+    QXmlStreamReader reader { svg };
+
+    while (!reader.atEnd()) {
+        reader.readNext();
+        if (reader.error() != QXmlStreamReader::NoError) {
+            return false;
+        }
+
+        bool isBreezeStylesheet = reader.isStartElement()
+            && reader.name() == "style"_L1
+            && reader.attributes().value("type"_L1) == "text/css"_L1
+            && reader.attributes().value("id"_L1) == "current-color-scheme"_L1;
+
+        if (isBreezeStylesheet) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void recolorIcon(QImage& image, const QColor& color)
+{
+    QRgb c = color.rgba();
+
+    for (int y = 0; y < image.height(); y++) {
+        QRgb* line = reinterpret_cast<QRgb*>(image.scanLine(y));
+        for (int x = 0; x < image.width(); x++) {
+            QRgb& rgb = line[x];
+            rgb = qRgba(qRed(c), qGreen(c), qBlue(c), qAlpha(rgb));
+        }
+    }
+}
+
+QPixmap CuteCosmicIconEngine::renderSvgIcon(const QString& path, const QSize& size, QIcon::Mode mode, QIcon::State state)
+{
+    Q_UNUSED(state);
+
+    QPalette appPalette = QGuiApplication::palette();
+
+    QString cacheKey;
+    QTextStream(&cacheKey) << "$cutecosmic|"_L1
+                           << path << "|"_L1
+                           << mode << "|"_L1
+                           << size.width() << "|"_L1
+                           << appPalette.cacheKey();
+
+    QPixmap result;
+    if (QPixmapCache::find(cacheKey, &result)) {
+        return result;
+    }
+
+    QFile file { path };
+    if (!file.open(QFile::ReadOnly)) {
+        return QPixmap();
+    }
+
+    QByteArray data = file.readAll();
+
+    QBuffer buffer { &data };
+    QImageReader reader { &buffer, "svg" };
+    reader.setScaledSize(size);
+
+    QImage image = reader.read().convertToFormat(QImage::Format_ARGB32);
+    if (isSymbolic(d_iconInfo.iconName) || isKdeSymbolicIcon(data)) {
+        // FIXME: Active icon tint should be HighlightedText really, but
+        // currently hovered menu items are painted with the highlight
+        // color but hovered toolbar items (and other buttons) don't, and
+        // that looks bad. Revisit with button palettes.
+        QColor tint = (mode == QIcon::Active)
+            ? appPalette.color(QPalette::Active, QPalette::Text)
+            : appPalette.color(QPalette::Active, QPalette::Text);
+
+        recolorIcon(image, tint);
+    }
+
+    result = QGuiApplicationPrivate::instance()->applyQIconStyleHelper(mode, QPixmap::fromImage(image));
+    QPixmapCache::insert(cacheKey, result);
+    return result;
+}
+
+static qreal directorySizeDistance(QIconDirInfo& dir, int size, qreal scale)
+{
+    // This is basically DirectorySizeDistance as listed in the XDG Icon Theme
+    // specification
+
+    const qreal scaledSize = size * scale;
+
+    if (dir.type == QIconDirInfo::Fixed) {
+        return qAbs(dir.size * dir.scale - scaledSize);
+    }
+    if (dir.type == QIconDirInfo::Scalable) {
+        if (scaledSize < dir.minSize * dir.scale) {
+            return dir.minSize * dir.scale - scaledSize;
+        }
+        else if (scaledSize > dir.maxSize * dir.scale) {
+            return scaledSize - dir.maxSize * dir.scale;
+        }
+        return 0;
+    }
+    if (dir.type == QIconDirInfo::Threshold) {
+        const qreal minScaledSize = (dir.size - dir.threshold) * dir.scale;
+        const qreal maxScaledSize = (dir.size + dir.threshold) * dir.scale;
+
+        if (scaledSize < minScaledSize) {
+            return minScaledSize - scaledSize;
+        }
+        else if (scaledSize > maxScaledSize) {
+            return scaledSize - maxScaledSize;
+        }
+        return 0;
+    }
+    return std::numeric_limits<qreal>::max();
+}
+
+QString CuteCosmicIconEngine::bestIconFileForSize(int size, qreal scale)
+{
+    qreal minDistance = std::numeric_limits<qreal>::max();
+    QString minDistancePath;
+
+    for (const auto& entry : std::as_const(d_iconInfo.entries)) {
+        qreal distance = directorySizeDistance(entry->dir, size, scale);
+        if (qFuzzyIsNull(distance)) {
+            // XDG spec says we have to use the first exactly matching icon
+            return entry->filename;
+        }
+
+        if (distance < minDistance) {
+            minDistance = distance;
+            minDistancePath = entry->filename;
+        }
+    }
+    return minDistancePath;
+}

--- a/platformtheme/cutecosmiciconengine.h
+++ b/platformtheme/cutecosmiciconengine.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of CuteCosmic.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <QIconEngine>
+
+#include <QtGui/private/qiconloader_p.h>
+
+class CuteCosmicIconEngine : public QIconEngine
+{
+public:
+    CuteCosmicIconEngine(const QString& iconName);
+
+    QIconEngine* clone() const override;
+
+    QString key() const override;
+    QString iconName() override;
+    bool isNull() override;
+
+    void paint(QPainter* painter, const QRect& rect, QIcon::Mode mode, QIcon::State state) override;
+    QPixmap pixmap(const QSize& size, QIcon::Mode mode, QIcon::State state) override;
+    QPixmap scaledPixmap(const QSize& size, QIcon::Mode mode, QIcon::State state, qreal scale) override;
+
+private:
+    QPixmap renderSvgIcon(const QString& path, const QSize& size, QIcon::Mode mode, QIcon::State state);
+
+    QString bestIconFileForSize(int size, qreal scale);
+
+    QThemeIconInfo d_iconInfo;
+};

--- a/platformtheme/cutecosmictheme.cpp
+++ b/platformtheme/cutecosmictheme.cpp
@@ -17,6 +17,7 @@
 #include "cutecosmictheme.h"
 #include "cutecosmiccolormanager.h"
 #include "cutecosmicfiledialog.h"
+#include "cutecosmiciconengine.h"
 #include "cutecosmicwatcher.h"
 
 #include "bindings.h"
@@ -32,6 +33,8 @@ static constexpr int DEFAULT_FONT_SIZE = QGenericUnixTheme::defaultSystemFontSiz
 // https://github.com/qt/qtbase/blob/6.9/src/gui/platform/unix/qgenericunixthemes.cpp#L78
 static constexpr int DEFAULT_FONT_SIZE = 9;
 #endif
+
+using namespace Qt::StringLiterals;
 
 static QString consumeRustString(char* value)
 {
@@ -162,17 +165,6 @@ QPlatformDialogHelper* CuteCosmicPlatformTheme::createPlatformDialogHelper(Dialo
     return QGenericUnixTheme::createPlatformDialogHelper(type);
 }
 
-Qt::ColorScheme CuteCosmicPlatformTheme::colorScheme() const
-{
-    bool dark = libcosmic_theme_is_dark();
-    return dark ? Qt::ColorScheme::Dark : Qt::ColorScheme::Light;
-}
-
-void CuteCosmicPlatformTheme::requestColorScheme(Qt::ColorScheme scheme)
-{
-    d_ptr->setColorScheme(scheme);
-}
-
 const QPalette* CuteCosmicPlatformTheme::palette(Palette type) const
 {
     if (type == QPlatformTheme::SystemPalette) {
@@ -200,8 +192,27 @@ QVariant CuteCosmicPlatformTheme::themeHint(ThemeHint hint) const
     if (hint == QPlatformTheme::SystemIconThemeName) {
         return consumeRustString(libcosmic_theme_icon_theme());
     }
+    else if (hint == QPlatformTheme::SystemIconFallbackThemeName) {
+        return "breeze"_L1;
+    }
 
     return QGenericUnixTheme::themeHint(hint);
+}
+
+QIconEngine* CuteCosmicPlatformTheme::createIconEngine(const QString& iconName) const
+{
+    return new CuteCosmicIconEngine(iconName);
+}
+
+Qt::ColorScheme CuteCosmicPlatformTheme::colorScheme() const
+{
+    bool dark = libcosmic_theme_is_dark();
+    return dark ? Qt::ColorScheme::Dark : Qt::ColorScheme::Light;
+}
+
+void CuteCosmicPlatformTheme::requestColorScheme(Qt::ColorScheme scheme)
+{
+    d_ptr->setColorScheme(scheme);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)

--- a/platformtheme/cutecosmictheme.h
+++ b/platformtheme/cutecosmictheme.h
@@ -63,13 +63,15 @@ public:
     bool usePlatformNativeDialog(DialogType type) const override;
     QPlatformDialogHelper* createPlatformDialogHelper(DialogType type) const override;
 
-    Qt::ColorScheme colorScheme() const override;
-    void requestColorScheme(Qt::ColorScheme scheme) override;
-
     const QPalette* palette(Palette type) const override;
     const QFont* font(Font type) const override;
 
     QVariant themeHint(ThemeHint hint) const override;
+
+    QIconEngine* createIconEngine(const QString& iconName) const override;
+
+    Qt::ColorScheme colorScheme() const override;
+    void requestColorScheme(Qt::ColorScheme scheme) override;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
     Qt::ContrastPreference contrastPreference() const override;


### PR DESCRIPTION
Use a custom icon engine for loading SVG icons from the XDG theme. It detects symbolic icons and re-colors them in the same way that is done in iced.