### PR TITLE
Defer configuration watching until event loop starts

### DIFF
--- a/platformtheme/cutecosmicwatcher.h
+++ b/platformtheme/cutecosmicwatcher.h
@@ -18,6 +18,8 @@
 
 #include <QObject>
 
+struct CosmicWatcherToken;
+
 class QTimer;
 
 class CuteCosmicWatcher : public QObject
@@ -32,8 +34,10 @@ Q_SIGNALS:
     void themeChanged();
 
 private Q_SLOTS:
+    void startWatching();
     void configurationChanged();
 
 private:
     QTimer* d_themeChangedEmitTimer;
+    CosmicWatcherToken* d_watcherToken;
 };


### PR DESCRIPTION
Can't post anything into the main Qt event loop until it exists, so start watching only when the Qt event loop starts to run. 

This avoids crashing on exit when an application creates a `QApplication` or a `QGuiApplication` but exits before executing it.