### PR TITLE
Expose a MiniFont to Qt

### DIFF
--- a/platformtheme/cutecosmictheme.cpp
+++ b/platformtheme/cutecosmictheme.cpp
@@ -38,6 +38,8 @@ static constexpr int DEFAULT_FONT_SIZE = QGenericUnixTheme::defaultSystemFontSiz
 static constexpr int DEFAULT_FONT_SIZE = 9;
 #endif
 
+static constexpr int MINI_FONT_SIZE = 8;
+
 Q_LOGGING_CATEGORY(lcCuteCosmic, "cutecosmic", QtWarningMsg)
 
 using namespace Qt::StringLiterals;
@@ -122,6 +124,11 @@ void CuteCosmicPlatformThemePrivate::reloadTheme()
 
     d_interfaceFont = loadFont(CosmicFontKind::Interface);
     d_monospaceFont = loadFont(CosmicFontKind::Monospace);
+
+    if (d_interfaceFont) {
+        d_miniFont = std::make_unique<QFont>(*d_interfaceFont);
+        d_miniFont->setPointSize(MINI_FONT_SIZE);
+    }
 }
 
 void CuteCosmicPlatformThemePrivate::setColorScheme(Qt::ColorScheme scheme)
@@ -218,6 +225,9 @@ const QFont* CuteCosmicPlatformTheme::font(Font type) const
     }
     if (type == QPlatformTheme::FixedFont) {
         return d_ptr->d_monospaceFont.get();
+    }
+    if (type == QPlatformTheme::MiniFont) {
+        return d_ptr->d_miniFont.get();
     }
     return nullptr;
 }

--- a/platformtheme/cutecosmictheme.h
+++ b/platformtheme/cutecosmictheme.h
@@ -53,6 +53,7 @@ private:
     Qt::ColorScheme d_requestedScheme;
     std::unique_ptr<QFont> d_interfaceFont;
     std::unique_ptr<QFont> d_monospaceFont;
+    std::unique_ptr<QFont> d_miniFont;
 };
 
 class CuteCosmicPlatformTheme : public QGenericUnixTheme


### PR DESCRIPTION
`QPlatformTheme::MiniFont` is indirectly queried by Kirigami (via `QFontDatabase::systemFont`). Without a value set for it - we are in the mercy of whatever fontconfig has to say, leading to inconsistent fonts in some Kirigami applications.