### PR TITLE
Implement full Breeze symbolic icon recoloring

### DIFF
--- a/platformtheme/cutecosmiccolormanager.cpp
+++ b/platformtheme/cutecosmiccolormanager.cpp
@@ -52,6 +52,7 @@ void CuteCosmicColorManager::reloadThemeColors()
 {
     rebuildPalettes();
     rebuildKdeColors();
+    rebuildKdeIconCss();
 }
 
 static QColor convertColor(const CosmicColor& color)
@@ -375,6 +376,33 @@ void CuteCosmicColorManager::rebuildKdeColors()
     if (saveFile.commit()) {
         QCoreApplication::instance()->setProperty("KDE_COLOR_SCHEME_PATH", d_kdeColorsFile->fileName());
     }
+}
+
+void CuteCosmicColorManager::rebuildKdeIconCss()
+{
+    Q_ASSERT(d_systemPalette.get() != nullptr);
+
+    CosmicExtendedPalette ep;
+    libcosmic_theme_get_extended_palette(&ep);
+
+    QColor windowText = d_systemPalette->color(QPalette::Active, QPalette::WindowText);
+    QColor windowBackground = d_systemPalette->color(QPalette::Active, QPalette::Window);
+    QColor highlightedText = d_systemPalette->color(QPalette::Active, QPalette::HighlightedText);
+    QColor accent = d_systemPalette->color(QPalette::Active, QPalette::Accent);
+    QColor negative = convertColor(ep.destructive);
+    QColor neutral = convertColor(ep.warning);
+    QColor positive = convertColor(ep.success);
+
+    d_iconCss.clear();
+    QTextStream stream { &d_iconCss };
+
+    stream << ".ColorScheme-Text{ color:" << windowText.name() << "; } ";
+    stream << ".ColorScheme-Background{ color:" << windowBackground.name() << "; } ";
+    stream << ".ColorScheme-HighlightedText{ color:" << highlightedText.name() << "; } ";
+    stream << ".ColorScheme-Accent{ color:" << accent.name() << "; }";
+    stream << ".ColorScheme-PositiveText{ color:" << positive.name() << "; } ";
+    stream << ".ColorScheme-NeutralText{ color:" << neutral.name() << "; } ";
+    stream << ".ColorScheme-NegativeText{ color:" << negative.name() << "; } ";
 }
 
 #include "moc_cutecosmiccolormanager.cpp"

--- a/platformtheme/cutecosmiccolormanager.h
+++ b/platformtheme/cutecosmiccolormanager.h
@@ -36,13 +36,17 @@ public:
     const QPalette* menuPalette() const { return d_menuPalette.get(); }
     const QPalette* buttonPalette() const { return d_buttonPalette.get(); }
 
+    QString iconCss() const { return d_iconCss; }
+
 private:
     void rebuildPalettes();
     void rebuildKdeColors();
+    void rebuildKdeIconCss();
 
     std::unique_ptr<QPalette> d_systemPalette;
     std::unique_ptr<QPalette> d_menuPalette;
     std::unique_ptr<QPalette> d_buttonPalette;
 
     QTemporaryFile* d_kdeColorsFile;
+    QString d_iconCss;
 };

--- a/platformtheme/cutecosmiciconengine.cpp
+++ b/platformtheme/cutecosmiciconengine.cpp
@@ -1,4 +1,5 @@
 #include "cutecosmiciconengine.h"
+#include "cutecosmiccolormanager.h"
 
 #include <QtGui/private/qguiapplication_p.h>
 
@@ -14,14 +15,15 @@
 
 using namespace Qt::Literals;
 
-CuteCosmicIconEngine::CuteCosmicIconEngine(const QString& iconName)
+CuteCosmicIconEngine::CuteCosmicIconEngine(const QString& iconName, CuteCosmicColorManager* colorManager)
     : d_iconInfo(QIconLoader::instance()->loadIcon(iconName))
+    , d_colorManager(colorManager)
 {
 }
 
 QIconEngine* CuteCosmicIconEngine::clone() const
 {
-    return new CuteCosmicIconEngine(d_iconInfo.iconName);
+    return new CuteCosmicIconEngine(d_iconInfo.iconName, d_colorManager);
 }
 
 QString CuteCosmicIconEngine::key() const
@@ -81,31 +83,44 @@ static bool isSymbolic(const QString& iconName)
         || iconName.endsWith("-symbolic-rtl"_L1);
 }
 
-static bool isKdeSymbolicIcon(const QByteArray& svg)
+static bool isOnKdeStylesheetElement(const QXmlStreamReader& reader)
 {
-    // Breeze icons are mostly symbolic, but not always found as such because
-    // of the internal symlinks in the theme. Furthermore, the way that KDE
-    // symbolic icons are re-colored is by a stylesheet embedded into the icon
-    // itself, which is replaced by KIconLoader prior to rendering. Try to
-    // identify this stylesheet.
-    QXmlStreamReader reader { svg };
+    return reader.isStartElement()
+        && reader.name() == "style"_L1
+        && reader.attributes().value("type"_L1) == "text/css"_L1
+        && reader.attributes().value("id"_L1) == "current-color-scheme"_L1;
+}
+
+static bool preprocessSvgIcon(QIODevice* in, QIODevice* out, const QString& iconCss)
+{
+    QXmlStreamReader reader { in };
+    QXmlStreamWriter writer { out };
+
+    bool isKdeSymbolic = false;
 
     while (!reader.atEnd()) {
         reader.readNext();
         if (reader.error() != QXmlStreamReader::NoError) {
-            return false;
+            break;
         }
 
-        bool isBreezeStylesheet = reader.isStartElement()
-            && reader.name() == "style"_L1
-            && reader.attributes().value("type"_L1) == "text/css"_L1
-            && reader.attributes().value("id"_L1) == "current-color-scheme"_L1;
+        if (isOnKdeStylesheetElement(reader)) {
+            writer.writeStartElement("style");
+            writer.writeAttributes(reader.attributes());
+            writer.writeCharacters(iconCss);
+            writer.writeEndElement();
 
-        if (isBreezeStylesheet) {
-            return true;
+            while (reader.tokenType() != QXmlStreamReader::EndElement && reader.error() == QXmlStreamReader::NoError) {
+                reader.readNext();
+            }
+            isKdeSymbolic = true;
+        }
+        else {
+            writer.writeCurrentToken(reader);
         }
     }
-    return false;
+
+    return isKdeSymbolic;
 }
 
 static void recolorIcon(QImage& image, const QColor& color)
@@ -144,14 +159,19 @@ QPixmap CuteCosmicIconEngine::renderSvgIcon(const QString& path, const QSize& si
         return QPixmap();
     }
 
-    QByteArray data = file.readAll();
+    QBuffer buffer;
+    if (!buffer.open(QBuffer::ReadWrite)) {
+        return QPixmap();
+    }
 
-    QBuffer buffer { &data };
+    bool isKdeSymbolic = preprocessSvgIcon(&file, &buffer, d_colorManager->iconCss());
+    buffer.seek(0);
+
     QImageReader reader { &buffer, "svg" };
     reader.setScaledSize(size);
 
     QImage image = reader.read().convertToFormat(QImage::Format_ARGB32);
-    if (isSymbolic(d_iconInfo.iconName) || isKdeSymbolicIcon(data)) {
+    if (isSymbolic(d_iconInfo.iconName) && !isKdeSymbolic) {
         QColor tint = appPalette.color(QPalette::Active, QPalette::Text);
         recolorIcon(image, tint);
     }

--- a/platformtheme/cutecosmiciconengine.h
+++ b/platformtheme/cutecosmiciconengine.h
@@ -20,10 +20,12 @@
 
 #include <QtGui/private/qiconloader_p.h>
 
+class CuteCosmicColorManager;
+
 class CuteCosmicIconEngine : public QIconEngine
 {
 public:
-    CuteCosmicIconEngine(const QString& iconName);
+    CuteCosmicIconEngine(const QString& iconName, CuteCosmicColorManager* colorManager);
 
     QIconEngine* clone() const override;
 
@@ -41,4 +43,5 @@ private:
     QString bestIconFileForSize(int size, qreal scale);
 
     QThemeIconInfo d_iconInfo;
+    CuteCosmicColorManager* d_colorManager;
 };

--- a/platformtheme/cutecosmictheme.cpp
+++ b/platformtheme/cutecosmictheme.cpp
@@ -254,7 +254,7 @@ QVariant CuteCosmicPlatformTheme::themeHint(ThemeHint hint) const
 
 QIconEngine* CuteCosmicPlatformTheme::createIconEngine(const QString& iconName) const
 {
-    return new CuteCosmicIconEngine(iconName);
+    return new CuteCosmicIconEngine(iconName, d_ptr->d_colorManager);
 }
 
 Qt::ColorScheme CuteCosmicPlatformTheme::colorScheme() const


### PR DESCRIPTION
Closes #10 

Recolor KDE style symbolic icons by injecting a full stylesheet into the SVG before rendering.